### PR TITLE
Add codeOwners in param of eval, so it can be used on client side

### DIFF
--- a/cli/src/occurences.js
+++ b/cli/src/occurences.js
@@ -91,7 +91,7 @@ const runEvals = (metrics, codeOwners) => {
   const promise = Promise.all(
     metrics.map(async (metric) => {
       spinnies.add(`metric_${metric.name}`, { text: `${metric.name}...`, indent: 4 })
-      const result = (await metric.eval(codeOwners)).map((occurrence) => ({ ...occurrence, metricName: metric.name }))
+      const result = (await metric.eval({codeOwners})).map((occurrence) => ({ ...occurrence, metricName: metric.name }))
       spinnies.succeed(`metric_${metric.name}`, { text: metric.name })
       return result
     })

--- a/cli/src/occurences.js
+++ b/cli/src/occurences.js
@@ -84,14 +84,14 @@ const matchPatterns = (files, metrics) => {
   return promise
 }
 
-const runEvals = (metrics) => {
+const runEvals = (metrics, codeOwners) => {
   if (!metrics.length) return []
 
   spinnies.add('evals', { text: 'Running eval()...', indent: 2 })
   const promise = Promise.all(
     metrics.map(async (metric) => {
       spinnies.add(`metric_${metric.name}`, { text: `${metric.name}...`, indent: 4 })
-      const result = (await metric.eval()).map((occurrence) => ({ ...occurrence, metricName: metric.name }))
+      const result = (await metric.eval(codeOwners)).map((occurrence) => ({ ...occurrence, metricName: metric.name }))
       spinnies.succeed(`metric_${metric.name}`, { text: metric.name })
       return result
     })
@@ -128,7 +128,7 @@ export const findOccurrences = async ({ configuration, files, metric, codeOwners
   // From ['loc'] to { 'loc': {} } to handle deprecated array configuration for plugins
   if (Array.isArray(plugins)) plugins = plugins.reduce((acc, value) => ({ ...acc, [value]: {} }), {})
 
-  const promise = Promise.all([matchPatterns(files, fileMetrics), runEvals(evalMetrics), runPlugins(plugins)])
+  const promise = Promise.all([matchPatterns(files, fileMetrics), runEvals(evalMetrics, codeOwners), runPlugins(plugins)])
 
   return _.flattenDeep(await promise).map(({ text, value, metricName, filePath, lineNumber, url, owners }) => ({
     text,


### PR DESCRIPTION
I have a case where I want to have access to codeOwners in eval.

The use case : 
  - I want to list occurrence of file which import a file owned by an other team.