### PR TITLE
js-unimported-plugin

### DIFF
--- a/.cherry.js
+++ b/.cherry.js
@@ -9,6 +9,7 @@ module.exports = {
     eslint: {},
     rubocop: {},
     jsCircularDependencies: { include: 'app/javascript/**' },
+    jsUnimported: { dir: 'cli' },
   },
   metrics: [
     {

--- a/cli/package.json
+++ b/cli/package.json
@@ -2,7 +2,7 @@
   "name": "cherrypush",
   "version": "1.0.102",
   "description": "CLI for the cherrypush app",
-  "main": "index.js",
+  "source": "./bin/cherry.js",
   "type": "module",
   "bin": {
     "cherry": "./bin/cherry.js"

--- a/cli/src/occurences.js
+++ b/cli/src/occurences.js
@@ -6,6 +6,7 @@ import { panic } from './error.js'
 import { buildPermalink } from './github.js'
 import eslint from './plugins/eslint.js'
 import jsCircularDependencies from './plugins/js_circular_dependencies.js'
+import jsUnimported from './plugins/js_unimported.js'
 import loc from './plugins/loc.js'
 import npmOutdated from './plugins/npm_outdated.js'
 import rubocop from './plugins/rubocop.js'
@@ -18,6 +19,7 @@ const PLUGINS = {
   eslint,
   loc,
   jsCircularDependencies,
+  jsUnimported,
   npmOutdated,
   yarnOutdated,
 }

--- a/cli/src/plugins/js_unimported.js
+++ b/cli/src/plugins/js_unimported.js
@@ -1,0 +1,30 @@
+import _ from 'lodash'
+import sh from '../sh.js'
+
+const getMetricName = (dir) => {
+  if (dir) return `npx unimported files (${dir})`
+  return 'npx unimported files'
+}
+
+const getCommand = (dir) => {
+  if (dir) return `npx unimported ${dir} --show-unused-files`
+  return `npx unimported --show-unused-files`
+}
+
+const run = async ({ dir }) => {
+  const { stdout } = await sh(getCommand(dir), { throwOnError: false })
+
+  return _.compact(
+    stdout.split('\n').map((line) => {
+      const [col1, col2, col3, filepath] = line.split(/\s+/)
+      if (!(col1 === '' && typeof parseInt(col2) == 'number' && col3 === '│')) return // remove irrelevant lines
+
+      return {
+        text: _.compact([dir, filepath]).join('/'),
+        metricName: getMetricName(dir),
+      }
+    })
+  )
+}
+
+export default { run }


### PR DESCRIPTION
We can now use `npx unimported` as a plugin: 

![image](https://github.com/cherrypush/cherrypush.com/assets/1740848/b72ae32f-e1e4-4960-be8e-dcd2453a6e49)

And running cherry locally should output: 

![image](https://github.com/cherrypush/cherrypush.com/assets/1740848/b662d2e8-481e-4549-9871-1b5790233b49)
